### PR TITLE
Symfony 5.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,14 @@ matrix:
       env: SYMFONY_VERSION='^3.4'
     - php: 7.2
       env: SYMFONY_VERSION='^4.2'
+    - php: 7.2
+      env: SYMFONY_VERSION='^5.0'
     - php: 7.3
       env: SYMFONY_VERSION='^3.4'
     - php: 7.3
       env: SYMFONY_VERSION='^4.2'
+    - php: 7.3
+      env: SYMFONY_VERSION='^5.0'
   fast_finish: true
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
     },
     "require": {
         "php": ">=7.1",
-        "symfony/framework-bundle": "^3.4|^4.0"
+        "symfony/framework-bundle": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
         "ext-redis": "*",
-        "symfony/phpunit-bridge": "^3.4|^4.0",
+        "symfony/phpunit-bridge": "^3.4|^4.0|^5.0",
         "doctrine/doctrine-bundle": "^1.10",
         "phpunit/phpunit": "^7",
         "friendsofphp/php-cs-fixer": "^2.14",
         "symfony/monolog-bundle": "^3.3",
-        "symfony/browser-kit": "^3.4|^4.0",
-        "symfony/yaml": "^3.4|^4.0"
+        "symfony/browser-kit": "^3.4|^4.0|^5.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "ext-redis": "*",
         "symfony/phpunit-bridge": "^3.4|^4.0|^5.0",
-        "doctrine/doctrine-bundle": "^1.10",
+        "doctrine/doctrine-bundle": "^1.10|^2.0",
         "phpunit/phpunit": "^7",
         "friendsofphp/php-cs-fixer": "^2.14",
         "symfony/monolog-bundle": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79f3b726fd7f4dafbe1ff95bbd07b45b",
+    "content-hash": "badf83655020a6fcb28ceeaffba492f6",
     "packages": [
         {
             "name": "psr/cache",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "badf83655020a6fcb28ceeaffba492f6",
+    "content-hash": "20ddf1db94e15d3f731890d66f0cd024",
     "packages": [
         {
             "name": "psr/cache",


### PR DESCRIPTION
I just setup your bundle with my fork which adds Symfony `^5.0` compatibility. So far, everything seems to work great. However, I haven't tested this extensively except for app + DB healthchecks. I don't see any issues why your bundle should not work with Symfony 5.x.