### PR TITLE
adjust typo in default redis port

### DIFF
--- a/src/Ekreative/HealthCheckBundle/DependencyInjection/RedisFactory.php
+++ b/src/Ekreative/HealthCheckBundle/DependencyInjection/RedisFactory.php
@@ -12,7 +12,7 @@ class RedisFactory
      *
      * @return \Redis
      */
-    public static function get($host, $port = 6739, $timeout = 5, $prefix = null)
+    public static function get($host, $port = 6379, $timeout = 5, $prefix = null)
     {
         set_error_handler(function ($severity, $message, $file, $line) {
             if ($severity & error_reporting()) {


### PR DESCRIPTION
I have tried to use your healthcheck, but everytime i got "connection refused", so i checked the source code and found a typo.
The default redis port is 6379 and not 6739