### PR TITLE
Removed deprecated argument `$errcontext` for `set_error_handler` since php 8.x

### DIFF
--- a/src/Ekreative/HealthCheckBundle/Controller/HealthCheckController.php
+++ b/src/Ekreative/HealthCheckBundle/Controller/HealthCheckController.php
@@ -82,7 +82,7 @@ class HealthCheckController
             }
         }
 
-        set_error_handler(function ($errno, $errstr, $errfile, $errline, array $errcontext) {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
             // error was suppressed with the @-operator
             if (0 === error_reporting()) {
                 return false;


### PR DESCRIPTION
The `set_error_handler` is currently receiving a deprecated argument which is not passed since php `> 8.0.0`. As the bundle requires php `8.x` (see https://www.php.net/manual/de/function.set-error-handler.php). In case of an error this will throw right now an error and not rendering the error page properly.

This PR removes the argument.