### PR TITLE
Add return type declaration in EkreativeHealthCheckExtension to address Symfony update warning

### DIFF
--- a/src/Ekreative/HealthCheckBundle/DependencyInjection/EkreativeHealthCheckExtension.php
+++ b/src/Ekreative/HealthCheckBundle/DependencyInjection/EkreativeHealthCheckExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class EkreativeHealthCheckExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);


### PR DESCRIPTION
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Ekreative\HealthCheckBundle\DependencyInjection\EkreativeHealthCheckExtension" now to avoid errors or add an explicit @return annotation to suppress this message.